### PR TITLE
[FIX] The stores used incorrectly the atoms :empty and :all

### DIFF
--- a/lib/chronik/aggregate.ex
+++ b/lib/chronik/aggregate.ex
@@ -257,7 +257,7 @@ defmodule Chronik.Aggregate do
     case store.fetch_by_aggregate(aggregate_tuple, version) do
       {:error, _} -> state
       {:ok, version, records} ->
-        log(id, "replaying events from #{inspect version} and on.")
+        log(id, "replaying events up to version: #{inspect version}.")
         new_state =
           records
           |> Enum.map(&Map.get(&1, :domain_event))

--- a/lib/chronik/projection.ex
+++ b/lib/chronik/projection.ex
@@ -193,7 +193,7 @@ defmodule Chronik.Projection do
   # Try to catch up to a future version coming from the PubSub
   # by fetching missing events from the Store.
   defp catch_up(version, projection_state, projection, store) do
-    from = if version == :empty do :all else version end
+    from = if version == :empty, do: :all, else: version
     case store.fetch(from) do
       {:ok, :empty, []} ->
         # There were no events on the Store to catch up.
@@ -216,7 +216,7 @@ defmodule Chronik.Projection do
     end
   end
   defp fetch_and_replay(version, state, projection, store) do
-    from = if version == :empty do :all else version end
+    from = if version == :empty, do: :all, else: version
     case store.fetch(from) do
       {:ok, :empty, []} ->
         warn(projection, "no events found in the store.")

--- a/lib/chronik/store/adapters/ecto/ecto.ex
+++ b/lib/chronik/store/adapters/ecto/ecto.ex
@@ -40,7 +40,7 @@ defmodule Chronik.Store.Adapters.Ecto do
   end
 
   def compare_version(a, a), do: :equal
-  def compare_version(:all, "0"), do: :next_one
+  def compare_version(:empty, "0"), do: :next_one
   def compare_version(a, b) when is_bitstring(a) and is_bitstring(b) do
     case {String.to_integer(a), String.to_integer(b)} do
       {v1, v2} when v2 == v1 + 1 -> :next_one
@@ -48,7 +48,7 @@ defmodule Chronik.Store.Adapters.Ecto do
       {v1, v2} when v2 < v1 -> :past
     end
   end
-  def compare_version(a, :all) when is_number(a), do: :past
+  def compare_version(a, :empty) when is_number(a), do: :past
   def compare_version(_, _), do: :error
 
   def child_spec(_store, opts) do
@@ -298,7 +298,7 @@ defmodule Chronik.Store.Adapters.Ecto do
 
   def domain_event(event, aggregate) do
     :erlang.binary_to_term(event)
-  catch
+  rescue
     _ ->
       Logger.error("could not load some events for " <>
                       "#{inspect aggregate} from the " <>

--- a/lib/chronik/store/adapters/ets/ets.ex
+++ b/lib/chronik/store/adapters/ets/ets.ex
@@ -35,7 +35,7 @@ defmodule Chronik.Store.Adapters.ETS do
   end
 
   def compare_version(a, a), do: :equal
-  def compare_version(:all, "0"), do: :next_one
+  def compare_version(:empty, "0"), do: :next_one
   def compare_version(a, b) when is_bitstring(a) and is_bitstring(b) do
     case {String.to_integer(a), String.to_integer(b)} do
       {v1, v2} when v2 == v1 + 1 -> :next_one

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Chronik.Mixfile do
   use Mix.Project
 
-  @version "0.1.5"
+  @version "0.1.6"
 
   def project do
     [


### PR DESCRIPTION
The Repo argument for fetch is :all but the state of the projection should be :empty