### PR TITLE
Adding a Store.current_version/0 function for projection without replay

### DIFF
--- a/lib/chronik/projection.ex
+++ b/lib/chronik/projection.ex
@@ -51,7 +51,9 @@ defmodule Chronik.Projection do
   The accepted `options`:
 
     * `:version` start replaying events from `version` and up. `:all`
-      indicates that the replay should be from the begining of times.
+      indicates that the replay should be from the begining of times while
+      `:current` means that no re-play should be made and start feeding domain
+      events from current version and on.
 
     * `:consistency` indicates how the projection should subscribe to
       the `Chronik.PubSub`. Possible values are `:eventual` (default) and
@@ -207,13 +209,8 @@ defmodule Chronik.Projection do
   end
 
   # Replay events from the store.
-  defp fetch_and_replay(:current, state, projection, store) do
-    # TODO: Query the store for only the version, not the whole records!
-    case store.fetch() do
-      {:ok, new_version, _records} ->
-          log(projection, "skipping re-playing")
-          {new_version, state}
-    end
+  defp fetch_and_replay(:current, state, _projection, store) do
+    {store.current_version(), state}
   end
   defp fetch_and_replay(version, state, projection, store) do
     from = if version == :empty, do: :all, else: version

--- a/lib/chronik/store.ex
+++ b/lib/chronik/store.ex
@@ -10,9 +10,9 @@ defmodule Chronik.Store do
   The version of a given event record in the Store.
 
   A simple implementation is a integer starting from 0. The atom
-  `:all` is the initial version (without events yet).
+  `:empty` is the initial version (without events yet).
   """
-  @type version :: term() | :all
+  @type version :: term() | :empty
 
   @typep events :: [Chronik.domain_event]
   @typep event_records :: [Chronik.EventRecord]
@@ -113,6 +113,11 @@ defmodule Chronik.Store do
   wich version of the aggregate was created.
   """
   @callback get_snapshot(aggregate :: Chronik.Aggregate) :: {version(), Chronik.Aggregate.state}
+
+  @doc """
+  Retrives the current version of the store. If there are no record returns :empty.
+  """
+  @callback current_version() :: version()
 
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do

--- a/lib/chronik/store/adapters/ecto/ecto.ex
+++ b/lib/chronik/store/adapters/ecto/ecto.ex
@@ -51,6 +51,8 @@ defmodule Chronik.Store.Adapters.Ecto do
   def compare_version(a, :empty) when is_number(a), do: :past
   def compare_version(_, _), do: :error
 
+  def current_version(), do: GenServer.call(@name, :current_version)
+
   def child_spec(_store, opts) do
     %{
       id: __MODULE__,
@@ -70,6 +72,9 @@ defmodule Chronik.Store.Adapters.Ecto do
     Repo.start_link([])
   end
 
+  def handle_call(:current_version, _from, state) do
+    {:reply, store_version(), state}
+  end
   # Write the events to the DB.
   def handle_call({:append, aggregate, events, opts}, _from, state) do
     aggregate_version = aggregate_version(aggregate)

--- a/test/chronik/aggregate/aggregate_test.exs
+++ b/test/chronik/aggregate/aggregate_test.exs
@@ -48,7 +48,7 @@ defmodule Chronik.Aggregate.Test do
       %CounterCreated{id: id, initial_value: 0}
     end
     def handle_command({:create, id}, _state) do
-       raise CartExistsError, "Cart #{inspect id} already created"
+       raise "cart #{inspect id} already created"
     end
     def handle_command({:increment, increment},
       %Counter{id: id, max: max, counter: counter})

--- a/test/chronik/store/store_test.exs
+++ b/test/chronik/store/store_test.exs
@@ -11,10 +11,15 @@ defmodule Chronik.Store.Test do
     aggregate = {:test_aggregate, "1"}
 
     assert {:ok, :empty, []} = store.fetch()
+    IO.inspect store.current_version()
+    assert :empty == store.current_version()
+
     # Test that events can be appended to the Store
     assert {:ok, version, [_, _]} = store.append(aggregate,
       [%CounterCreated{id: "11", initial_value: 0},
        %CounterIncremented{id: "11", increment: 3}], version: :any)
+
+    assert :empty != store.current_version()
 
     # If the stream exists and appending with version: :no_stream an error
     # should occurr


### PR DESCRIPTION
The projection now includes a `:current` version to tell Chronik not to do replay and to start from current version of the store.