### PR TITLE
Compress aggregate state and domain events

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,3 +10,6 @@ config :chronik, Chronik.Store.Adapters.Ecto.ChronikRepo,
   adapter: Ecto.Adapters.MySQL,
   url: {:system, "CHRONIK_REPO_URL", "ecto://root:root@localhost/chronik"}
 
+config :chronik, Chronik.Store.Adapters.Ecto,
+  aggregate_snapshot_compression_level: 1,
+  domain_event_compression_level: 9

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,4 +14,3 @@ config :chronik, Chronik.Aggregate.Test.Counter,
 
 config :chronik, Chronik.Store.Test.TestStore,
   adapter: Chronik.Store.Adapters.ETS
-  

--- a/lib/chronik/store/adapters/ecto/ecto.ex
+++ b/lib/chronik/store/adapters/ecto/ecto.ex
@@ -178,7 +178,7 @@ defmodule Chronik.Store.Adapters.Ecto do
     |> where(aggregate_id: ^id)
     |> Repo.update_all(
       set: [snapshot_version: version,
-            snapshot: :erlang.term_to_binary(aggregate_state)])
+            snapshot: :erlang.term_to_binary(aggregate_state, compressed: 1)])
 
     {:reply, :ok, state}
   end
@@ -311,7 +311,7 @@ defmodule Chronik.Store.Adapters.Ecto do
 
     %{
       aggregate_id: aggregate_id,
-      domain_event: :erlang.term_to_binary(record.domain_event),
+      domain_event: :erlang.term_to_binary(record.domain_event, compressed: 1),
       domain_event_json: json,
       aggregate_version: String.to_integer(record.aggregate_version),
       version: String.to_integer(record.version),

--- a/lib/chronik/store/adapters/ecto/ecto.ex
+++ b/lib/chronik/store/adapters/ecto/ecto.ex
@@ -1,5 +1,18 @@
 defmodule Chronik.Store.Adapters.Ecto do
-  @moduledoc false
+  @moduledoc """
+  Ecto adapter for `Chronik.Store`
+
+  ## Configuration
+
+  You can configure compression for the aggregate state and domain
+  events only for this adapter. By default both values are at 0
+  (compression disabled).
+
+  - `:aggregate_compression_level`
+  - `:domain_event_compression_level`
+
+  Both accept an integer from 0 to 9, being 9 the highest compression.
+  """
 
   @behaviour Chronik.Store
 
@@ -16,6 +29,9 @@ defmodule Chronik.Store.Adapters.Ecto do
 
   @name __MODULE__
   @epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
+
+  @aggregate_compression Application.get_env(:chronik, __MODULE__)[:aggregate_compression_level] || 0
+  @domain_event_compression Application.get_env(:chronik, __MODULE__)[:domain_event_compression_level] || 0
 
   # API
 
@@ -178,7 +194,7 @@ defmodule Chronik.Store.Adapters.Ecto do
     |> where(aggregate_id: ^id)
     |> Repo.update_all(
       set: [snapshot_version: version,
-            snapshot: :erlang.term_to_binary(aggregate_state, compressed: 1)])
+            snapshot: :erlang.term_to_binary(aggregate_state, compressed: @aggregate_compression)])
 
     {:reply, :ok, state}
   end
@@ -311,7 +327,7 @@ defmodule Chronik.Store.Adapters.Ecto do
 
     %{
       aggregate_id: aggregate_id,
-      domain_event: :erlang.term_to_binary(record.domain_event, compressed: 1),
+      domain_event: :erlang.term_to_binary(record.domain_event, compressed: @domain_event_compression),
       domain_event_json: json,
       aggregate_version: String.to_integer(record.aggregate_version),
       version: String.to_integer(record.version),


### PR DESCRIPTION
While using the Ecto adapter we would like to compress both the aggregate state and domain events to save a few bytes.

This is a bit awkward as it is an adapter specific configuration but we will generalize such options in the next releases.